### PR TITLE
Accept offset and size parameters passed into the constructor

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -35,6 +35,8 @@ To make your sketch capturing exceptions include [EspSaveCrash](https://github.c
 
 ```cpp
 #include "EspSaveCrash.h"
+
+EspSaveCrash SaveCrash;
 ```
 
 That's it.
@@ -170,18 +172,15 @@ Once module connects to the network, after opening provided IP in a web browser,
 
 ## Library Configuration
 
-Crash data are saved using the [EEPROM](https://github.com/esp8266/Arduino/blob/master/doc/libraries.md#eeprom) library that is provided together with [esp8266 / Arduino](https://github.com/esp8266/Arduino) core.
+Crash data is saved using the [EEPROM](https://github.com/esp8266/Arduino/blob/master/doc/libraries.md#eeprom) library that is provided together with [esp8266 / Arduino](https://github.com/esp8266/Arduino) core.
 
-If you like to change flash memory space reserved for storing crash information use define below. The maximum value is `4096` (`0x1000`) bytes as defined for the [EEPROM](https://github.com/esp8266/Arduino/blob/master/doc/libraries.md#eeprom) library.
+If you like to change flash memory space reserved for storing crash information use class constructor. The maximum value is `4096` (`0x1000`) bytes as defined for the [EEPROM](https://github.com/esp8266/Arduino/blob/master/doc/libraries.md#eeprom) library.
 
-```cpp
-#define SAVE_CRASH_SPACE_SIZE       0x0200  // space reserved to store crash data
-```
-
-You may have other applications already using EEPROM. With parameter `SAVE_CRASH_EEPROM_OFFSET` you can allocate initial EEPROM space for the other applications. Optionally use for this purpose upper EEPROM space (i.e. above `SAVE_CRASH_EEPROM_OFFSET` + `SAVE_CRASH_SPACE_SIZE`).
+You may have other applications already using EEPROM. Passing an offset parameter to the constructor leaves initial EEPROM space for the other applications. Optionally you can use upper EEPROM space (i.e. above `_offset` + `_size`).
 
 ```cpp
-#define SAVE_CRASH_EEPROM_OFFSET    0x0010  // adjust it to reserve space to store other data in EEPROM
+//Offset, Size
+EspSaveCrash SaveCrash(0x0010, 0x0200);
 ```
 
 Picture below shows relationship between both configuration parameters and total available EEPROM space.

--- a/examples/ExtendedCrashTester/ExtendedCrashTester.ino
+++ b/examples/ExtendedCrashTester/ExtendedCrashTester.ino
@@ -28,6 +28,8 @@
 
 #include "EspSaveCrash.h"
 
+//Offset and size parameters can be passed to the constructor
+EspSaveCrash SaveCrash(0x0020, 0x0200);
 
 void setup(void)
 {

--- a/examples/RemoteCrashCheck/RemoteCrashCheck.ino
+++ b/examples/RemoteCrashCheck/RemoteCrashCheck.ino
@@ -29,6 +29,8 @@
 #include "EspSaveCrash.h"
 #include <ESP8266WiFi.h>
 
+EspSaveCrash SaveCrash;
+
 const char* ssid = "********";
 const char* password = "********";
 

--- a/examples/SimpleCrash/SimpleCrash.ino
+++ b/examples/SimpleCrash/SimpleCrash.ino
@@ -28,6 +28,8 @@
 
 #include "EspSaveCrash.h"
 
+EspSaveCrash SaveCrash;
+
 void setup(void)
 {
   Serial.begin(115200);

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "EspSaveCrash",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "keywords": "crash, exception, restart, software WDT, diagnostics",
     "description": "Automatically saves exception details and stack trace to flash in case of ESP8266 crash.",
     "repository":

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,12 @@ You will implement it in your sketch in two simple steps:
   #include "EspSaveCrash.h"
   ```
 
-2. Print out saved crash details
+2. Declare object
+  ```cpp
+EspSaveCrash SaveCrash;
+```
+
+3. Print out saved crash details
   ```cpp
   SaveCrash.print();
   ```

--- a/src/EspSaveCrash.h
+++ b/src/EspSaveCrash.h
@@ -33,17 +33,6 @@
 #include "EEPROM.h"
 #include "user_interface.h"
 
-
-/**
- * User configuration of EEPROM layout
- *
- * Note that for using EEPROM we are also reserving a RAM buffer
- * The buffer size will be bigger by SAVE_CRASH_EEPROM_OFFSET than what we actually need
- * The space that we really need is defined by SAVE_CRASH_SPACE_SIZE
- */
-#define SAVE_CRASH_EEPROM_OFFSET    0x0010  // adjust it to reserve space to store other data in EEPROM
-#define SAVE_CRASH_SPACE_SIZE       0x0200  // space reserved to store crash data
-
 /**
  * Layout of crash data saved to EEPROM (flash)
  *
@@ -89,24 +78,28 @@
 #define SAVE_CRASH_STACK_TRACE      0x22  // variable
 
 
-class EspSaveCrash
+class EspSaveCrash 
 {
   public:
-    EspSaveCrash();
+    EspSaveCrash(uint16_t = 0x0010, uint16_t = 0x0200);
+    ~EspSaveCrash();
     void print(Print& outDevice = Serial);
     void clear();
     int count();
+    uint16_t offset();
+    uint16_t size();
 
+    //These have to be public in order to be accessed by callback
+    static uint16_t _offset;
+    static uint16_t _size;
   private:
     // none
 };
 
-
-extern EspSaveCrash SaveCrash;
-
+//TODO: How to gracefully report to user with new static vars?
 // check if configuration of EEPROM layout will fit into EEPROM sector size
-#if SAVE_CRASH_EEPROM_OFFSET + SAVE_CRASH_SPACE_SIZE > SPI_FLASH_SEC_SIZE
-  #warning Check configuration of EEPROM layout!
-#endif
+//#if SAVE_CRASH_EEPROM_OFFSET + SAVE_CRASH_SPACE_SIZE > SPI_FLASH_SEC_SIZE
+//  #warning Check configuration of EEPROM layout!
+//#endif
 
 #endif //_ESPSAVECRASH_H_

--- a/src/EspSaveCrash.h
+++ b/src/EspSaveCrash.h
@@ -82,7 +82,6 @@ class EspSaveCrash
 {
   public:
     EspSaveCrash(uint16_t = 0x0010, uint16_t = 0x0200);
-    ~EspSaveCrash();
     void print(Print& outDevice = Serial);
     void clear();
     int count();


### PR DESCRIPTION
EEPROM library now gets initialised only once in the constructor and is ended in the destructor.