### PR TITLE
crash log can be stored to char buffer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 _input
 Thumbs.db
+
+wifiConfig.h

--- a/examples/RemoteCrashCheck/RemoteCrashCheck.ino
+++ b/examples/RemoteCrashCheck/RemoteCrashCheck.ino
@@ -28,105 +28,73 @@
 
 #include "EspSaveCrash.h"
 #include <ESP8266WiFi.h>
-#include <ESP8266WiFiMulti.h>
-#include <WiFiClient.h>
-#include <ESP8266WebServer.h>
-#include <ESP8266mDNS.h>
-
-// WiFi ssid and password defined in wifiConfig.h
-// file is tracked with gitignore
-// #include "wifiConfig.h"
-const char* ssid = "********";
-const char* password = "********";
 
 EspSaveCrash SaveCrash;
 
-ESP8266WebServer server(80);
+const char* ssid = "********";
+const char* password = "********";
 
-// the buffer to put the Crash log to
-char *_debugOutputBuffer;
+WiFiServer server(80);
 
-// flag for setting up the server with WiFiMulti.addAP
-uint8_t performOnce = 0;
 
 void setup(void)
 {
-  // 2048 should be able to carry most of the debug stuff
-  _debugOutputBuffer = (char *) calloc(2048, sizeof(char));
-
   Serial.begin(115200);
   Serial.println("\nRemoteCrashCheck.ino");
 
   SaveCrash.print();
 
   Serial.printf("Connecting to %s ", ssid);
-
-  // WiFi.persistent(false);
-  WiFi.mode(WIFI_STA);
-
-  // remove if using WiFiMulti.addAP
+  WiFi.persistent(false);
   WiFi.begin(ssid, password);
-  // Wait for connection
   while (WiFi.status() != WL_CONNECTED)
   {
     delay(500);
     Serial.print(".");
   }
-  // end of remove
-
-  // non blocking WiFi login, will be added to onboard WiFi settings
-  // WiFiMulti.addAP(ssid, password);
-  // you have to wait until WiFi.status() == WL_CONNECTED
-  // before starting MDNS and the webserver
-
   Serial.println(" connected");
 
-  server.on("/", handleRoot);
-  server.on("/log", handleLog);
-  server.onNotFound(handleNotFound);
-
-  Serial.printf("HTTP server started, open %s in a web browser\n", WiFi.localIP().toString().c_str());
-
-  // remove if using WiFiMulti.addAP
   server.begin();
-  if (MDNS.begin("esp8266"))
-  {
-    Serial.println("MDNS responder started");
-  }
-  // end of remove
-
+  Serial.printf("Web server started, open %s in a web browser\n", WiFi.localIP().toString().c_str());
   Serial.println("\nPress a key + <enter>");
   Serial.println("0 : attempt to divide by zero");
   Serial.println("e : attempt to read through a pointer to no object");
   Serial.println("c : clear crash information");
-  Serial.println("p : print crash information");
-  Serial.println("b : store crash information to buffer and print buffer");
 }
 
 
 void loop(void)
 {
-  server.handleClient();
-  MDNS.update();
-
-  /*
-  // uncomment if using WiFiMulti.addAP
-  // if a WiFi connection is successfully established
-  if (WiFi.status() == WL_CONNECTED)
+  // read line by line what the client (web browser) is requesting
+  WiFiClient client = server.available();
+  if (client)
   {
-    if (performOnce == 0)
+    Serial.println("\n[Client connected]");
+    while (client.connected())
     {
-      performOnce = 1;
-
-      server.begin();
-      if (MDNS.begin("esp8266"))
+      // read line by line what the client (web browser) is requesting
+      if (client.available())
       {
-        Serial.println("MDNS responder started");
+        String line = client.readStringUntil('\r');
+        // look for the end of client's request, that is marked with an empty line
+        if (line.length() == 1 && line[0] == '\n')
+        {
+          // send response header to the web browser
+          client.print("HTTP/1.1 200 OK\r\n");
+          client.print("Content-Type: text/plain\r\n");
+          client.print("Connection: close\r\n");
+          client.print("\r\n");
+          // send crash information to the web browser
+          SaveCrash.print(client);
+          break;
+        }
       }
     }
+    delay(1); // give the web browser time to receive the data
+    // close the connection:
+    client.stop();
+    Serial.println("[Client disonnected]");
   }
-  // end of uncomment
-  */
 
   // read the keyboard
   if (Serial.available() > 0)
@@ -154,54 +122,9 @@ void loop(void)
         SaveCrash.clear();
         Serial.println("Crash information cleared");
         break;
-      case 'p':
-        Serial.println("--- BEGIN of crash info ---");
-        SaveCrash.print();
-        Serial.println("--- END of crash info ---");
-        break;
-      case 'b':
-        // "clear" the buffer before serving a request
-        strcpy(_debugOutputBuffer, "");
-        Serial.println("--- BEGIN of crash info ---");
-        SaveCrash.crashToBuffer(_debugOutputBuffer);
-        Serial.println(_debugOutputBuffer);
-        Serial.println("--- END of crash info ---");
-        break;
       default:
         Serial.printf("%c typed\n", inChar);
         break;
     }
   }
-}
-
-void handleRoot()
-{
-  server.send(200, "text/html", "<html><body>Hello from ESP<br><a href='/log'>Crash Log</a></body></html>");
-}
-
-void handleLog()
-{
-  // "clear" the buffer before serving a request
-  strcpy(_debugOutputBuffer, "");
-
-  SaveCrash.crashToBuffer(_debugOutputBuffer);
-
-  server.send(200, "text/plain", _debugOutputBuffer);
-}
-
-void handleNotFound()
-{
-  String message = "File Not Found\n\n";
-  message += "URI: ";
-  message += server.uri();
-  message += "\nMethod: ";
-  message += (server.method() == HTTP_GET) ? "GET" : "POST";
-  message += "\nArguments: ";
-  message += server.args();
-  message += "\n";
-  for (uint8_t i = 0; i < server.args(); i++)
-  {
-    message += " " + server.argName(i) + ": " + server.arg(i) + "\n";
-  }
-  server.send(404, "text/plain", message);
 }

--- a/examples/SimpleCrash/SimpleCrash.ino
+++ b/examples/SimpleCrash/SimpleCrash.ino
@@ -30,8 +30,12 @@
 
 EspSaveCrash SaveCrash;
 
+char *_debugOutputBuffer;
+
 void setup(void)
 {
+  _debugOutputBuffer = (char *) calloc(2048, sizeof(char));
+
   Serial.begin(115200);
   Serial.println();
   Serial.println("SimpleCrash.ino");
@@ -42,6 +46,8 @@ void setup(void)
   Serial.println("0 : attempt to divide by zero");
   Serial.println("e : attempt to read through a pointer to no object");
   Serial.println("c : clear crash information");
+  Serial.println("p : print crash information");
+  Serial.println("b : store crash information to buffer and print buffer");
   Serial.println();
 }
 
@@ -72,6 +78,17 @@ void loop(void)
       case 'c':
         SaveCrash.clear();
         Serial.println("Crash information cleared");
+        break;
+      case 'p':
+        Serial.println("--- BEGIN of crash info ---");
+        SaveCrash.print();
+        Serial.println("--- END of crash info ---");
+        break;
+      case 'b':
+        SaveCrash.crashToBuffer(_debugOutputBuffer);
+        Serial.println("--- BEGIN of crash info from buffer ---");
+        Serial.println(_debugOutputBuffer);
+        Serial.println("--- END of crash info from buffer ---");
         break;
       default:
         Serial.printf("%c typed\n", inChar);

--- a/examples/WebServerCrashCheck/WebServerCrashCheck.ino
+++ b/examples/WebServerCrashCheck/WebServerCrashCheck.ino
@@ -1,0 +1,213 @@
+/*
+  Example application to show how to save crash information
+  to ESP8266's flash using EspSaveCrash library
+  Please check repository below for details
+
+  Repository: https://github.com/krzychb/EspSaveCrash
+  File: WebServerCrashCheck.ino
+  Revision: 1.0.0
+  Date: 30-September-2019
+  Author: brainelectronics at brainelectronics.com
+  Based on code written by: krzychb at gazeta.pl
+
+  Copyright (c) 2019 Jonas Scharpf. All rights reserved.
+
+  This application is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This application is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#include "EspSaveCrash.h"
+#include <ESP8266WiFi.h>
+#include <ESP8266WiFiMulti.h>
+#include <WiFiClient.h>
+#include <ESP8266WebServer.h>
+#include <ESP8266mDNS.h>
+
+// WiFi ssid and password defined in wifiConfig.h
+// file is tracked with gitignore
+#include "wifiConfig.h"
+
+EspSaveCrash SaveCrash;
+
+ESP8266WebServer server(80);
+
+ESP8266WiFiMulti WiFiMulti;
+
+// the buffer to put the Crash log to
+char *_debugOutputBuffer;
+
+// flag for setting up the server with WiFiMulti.addAP
+uint8_t performOnce = 0;
+
+void setup(void)
+{
+  // 2048 should be able to carry most of the debug stuff
+  _debugOutputBuffer = (char *) calloc(2048, sizeof(char));
+
+  Serial.begin(115200);
+  Serial.println("\nWebServerCrashCheck.ino");
+
+  SaveCrash.print();
+
+  Serial.printf("Connecting to %s ", ssid);
+
+  // WiFi.persistent(false);
+  WiFi.mode(WIFI_STA);
+
+  // credentials will be added to onboard WiFi settings
+  WiFiMulti.addAP(ssid, password);
+  // you have to wait until WiFi.status() == WL_CONNECTED
+  // before starting MDNS and the webserver
+  WiFi.begin(ssid, password);
+  while (WiFi.status() != WL_CONNECTED)
+  {
+    delay(500);
+    Serial.print(".");
+  }
+  Serial.println(" connected");
+
+  // create AccessPoint with custom network name and password
+  WiFi.softAP(accessPointSsid, accessPointPassword);
+  Serial.printf("AccessPoint created. Connect to '%s' network and open '%s' in a web browser\n", accessPointSsid, WiFi.softAPIP().toString().c_str());
+
+  server.on("/", handleRoot);
+  server.on("/log", handleLog);
+  server.onNotFound(handleNotFound);
+
+  // start the http server
+  server.begin();
+
+  Serial.println("\nPress a key + <enter>");
+  Serial.println("0 : attempt to divide by zero");
+  Serial.println("e : attempt to read through a pointer to no object");
+  Serial.println("c : clear crash information");
+  Serial.println("p : print crash information");
+  Serial.println("b : store crash information to buffer and print buffer");
+  Serial.println("i : print IP address");
+}
+
+void loop(void)
+{
+  server.handleClient();
+  MDNS.update();
+
+  // if a WiFi connection is successfully established
+  if (WiFi.status() == WL_CONNECTED)
+  {
+    // if the following action has not been perfomed yet
+    if (performOnce == 0)
+    {
+      // change the flag
+      performOnce = 1;
+
+      if (MDNS.begin("esp8266"))
+      {
+        MDNS.addService("http", "tcp", 80);
+
+        Serial.println("MDNS responder started");
+      }
+
+      Serial.printf("Connected to '%s'. Open '%s' or 'esp8266.local' in a web browser\n", ssid, WiFi.localIP().toString().c_str());
+    }
+  }
+
+  // read the keyboard
+  if (Serial.available() > 0)
+  {
+    char inChar = Serial.read();
+
+    switch (inChar)
+    {
+      case '0':
+        Serial.println("Attempting to divide by zero ...");
+        int result, zero;
+        zero = 0;
+        result = 1 / zero;
+        Serial.print("Result = ");
+        Serial.println(result);
+        break;
+      case 'e':
+        Serial.println("Attempting to read through a pointer to no object ...");
+        int* nullPointer;
+        nullPointer = NULL;
+        // null pointer dereference - read
+        // attempt to read a value through a null pointer
+        Serial.print(*nullPointer);
+        break;
+      case 'c':
+        SaveCrash.clear();
+        Serial.println("Crash information cleared");
+        break;
+      case 'p':
+        Serial.println("--- BEGIN of crash info ---");
+        SaveCrash.print();
+        Serial.println("--- END of crash info ---");
+        break;
+      case 'b':
+        // "clear" the buffer before serving a request
+        strcpy(_debugOutputBuffer, "");
+        Serial.println("--- BEGIN of crash info ---");
+        SaveCrash.crashToBuffer(_debugOutputBuffer);
+        Serial.println(_debugOutputBuffer);
+        Serial.println("--- END of crash info ---");
+        break;
+      case 'i':
+        // print the IP address of the http server
+        if (performOnce == 1)
+        {
+          Serial.printf("Connected to '%s' with IP address: %s\n", ssid, WiFi.localIP().toString().c_str());
+        }
+        else
+        {
+          Serial.printf("Connection to network '%s' not yet established\n", ssid);
+        }
+        Serial.printf("Connect to AccessPoint '%s' at IP address: %s\n", accessPointSsid, WiFi.softAPIP().toString().c_str());
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+void handleRoot()
+{
+  server.send(200, "text/html", "<html><body>Hello from ESP<br><a href='/log'>Crash Log</a></body></html>");
+}
+
+void handleLog()
+{
+  // "clear" the buffer before serving a request
+  strcpy(_debugOutputBuffer, "");
+
+  SaveCrash.crashToBuffer(_debugOutputBuffer);
+
+  server.send(200, "text/plain", _debugOutputBuffer);
+}
+
+void handleNotFound()
+{
+  String message = "File Not Found\n\n";
+  message += "URI: ";
+  message += server.uri();
+  message += "\nMethod: ";
+  message += (server.method() == HTTP_GET) ? "GET" : "POST";
+  message += "\nArguments: ";
+  message += server.args();
+  message += "\n";
+  for (uint8_t i = 0; i < server.args(); i++)
+  {
+    message += " " + server.argName(i) + ": " + server.arg(i) + "\n";
+  }
+  server.send(404, "text/plain", message);
+}

--- a/examples/WebServerCrashCheck/wifiConfig.h
+++ b/examples/WebServerCrashCheck/wifiConfig.h
@@ -1,0 +1,7 @@
+// enter the credentials of your network
+const char* ssid = "********";
+const char* password = "********";
+
+// create an access point with a custom name and password
+const char* accessPointSsid = "********";
+const char* accessPointPassword = "********";

--- a/src/EspSaveCrash.cpp
+++ b/src/EspSaveCrash.cpp
@@ -227,12 +227,10 @@ void EspSaveCrash::crashToBuffer(char* userBuffer)
   byte crashCounter = EEPROM.read(_offset + SAVE_CRASH_COUNTER);
   if (crashCounter == 0)
   {
-    // outputDev.println("No crashes saved");
     strcpy(userBuffer, "No crashes saved");
     return;
   }
 
-  // outputDev.println("Crash information recovered from EEPROM");
   strcat(userBuffer, "Crash information recovered from EEPROM\n");
 
   int16_t readFrom = _offset + SAVE_CRASH_DATA_SETS;
@@ -240,15 +238,12 @@ void EspSaveCrash::crashToBuffer(char* userBuffer)
   {
     uint32_t crashTime;
     EEPROM.get(readFrom + SAVE_CRASH_CRASH_TIME, crashTime);
-    // outputDev.printf("Crash # %d at %ld ms\n", k + 1, crashTime);
     sprintf(tmpBuffer, "Crash # %d at %ld ms\n", k + 1, crashTime);
     strcat(userBuffer, tmpBuffer);
 
-    // outputDev.printf("Restart reason: %d\n", EEPROM.read(readFrom + SAVE_CRASH_RESTART_REASON));
     sprintf(tmpBuffer, "Restart reason: %d\n", EEPROM.read(readFrom + SAVE_CRASH_RESTART_REASON));
     strcat(userBuffer, tmpBuffer);
 
-    // outputDev.printf("Exception cause: %d\n", EEPROM.read(readFrom + SAVE_CRASH_EXCEPTION_CAUSE));
     sprintf(tmpBuffer, "Exception cause: %d\n", EEPROM.read(readFrom + SAVE_CRASH_EXCEPTION_CAUSE));
     strcat(userBuffer, tmpBuffer);
 
@@ -258,14 +253,12 @@ void EspSaveCrash::crashToBuffer(char* userBuffer)
     EEPROM.get(readFrom + SAVE_CRASH_EPC3, epc3);
     EEPROM.get(readFrom + SAVE_CRASH_EXCVADDR, excvaddr);
     EEPROM.get(readFrom + SAVE_CRASH_DEPC, depc);
-    // outputDev.printf("epc1=0x%08x epc2=0x%08x epc3=0x%08x excvaddr=0x%08x depc=0x%08x\n", epc1, epc2, epc3, excvaddr, depc);
     sprintf(tmpBuffer, "epc1=0x%08x epc2=0x%08x epc3=0x%08x excvaddr=0x%08x depc=0x%08x\n", epc1, epc2, epc3, excvaddr, depc);
     strcat(userBuffer, tmpBuffer);
 
     uint32_t stackStart, stackEnd;
     EEPROM.get(readFrom + SAVE_CRASH_STACK_START, stackStart);
     EEPROM.get(readFrom + SAVE_CRASH_STACK_END, stackEnd);
-    // outputDev.println(">>>stack>>>");
     sprintf(tmpBuffer, ">>>stack>>>\n");
     strcat(userBuffer, tmpBuffer);
 
@@ -274,33 +267,28 @@ void EspSaveCrash::crashToBuffer(char* userBuffer)
     uint32_t stackTrace;
     for (int16_t i = 0; i < stackLength; i += 0x10)
     {
-      // outputDev.printf("%08x: ", stackStart + i);
       sprintf(tmpBuffer, "%08x: ", stackStart + i);
       strcat(userBuffer, tmpBuffer);
 
       for (byte j = 0; j < 4; j++)
       {
         EEPROM.get(currentAddress, stackTrace);
-        // outputDev.printf("%08x ", stackTrace);
         sprintf(tmpBuffer, "%08x ", stackTrace);
         strcat(userBuffer, tmpBuffer);
 
         currentAddress += 4;
         if (currentAddress - _offset > _size)
         {
-          // outputDev.println("\nIncomplete stack trace saved!");
           sprintf(tmpBuffer, "\nIncomplete stack trace saved!\n");
           strcat(userBuffer, tmpBuffer);
 
           goto eepromSpaceEnd;
         }
       }
-      // outputDev.println();
       strcat(userBuffer, "\n");
 
     }
     eepromSpaceEnd:
-    // outputDev.println("<<<stack<<<");
     strcat(userBuffer, "<<<stack<<<\n");
 
     readFrom = readFrom + SAVE_CRASH_STACK_TRACE + stackLength;
@@ -312,12 +300,10 @@ void EspSaveCrash::crashToBuffer(char* userBuffer)
   // is there free EEPROM space avialable to save data for next crash?
   if (writeFrom + SAVE_CRASH_STACK_TRACE > _size)
   {
-    // outputDev.println("No more EEPROM space available to save crash information!");
     strcat(userBuffer, "No more EEPROM space available to save crash information!\n");
   }
   else
   {
-    // outputDev.printf("EEPROM space available: 0x%04x bytes\n", _size - writeFrom);
     sprintf(tmpBuffer, "EEPROM space available: 0x%04x bytes\n", _size - writeFrom);
     strcat(userBuffer, tmpBuffer);
   }

--- a/src/EspSaveCrash.cpp
+++ b/src/EspSaveCrash.cpp
@@ -112,7 +112,7 @@ extern "C" void custom_crash_callback(struct rst_info * rst_info, uint32_t stack
 
 
 /**
- * The class constructor 
+ * The class constructor
  */
 EspSaveCrash::EspSaveCrash(uint16_t off, uint16_t size)
 {
@@ -213,6 +213,117 @@ void EspSaveCrash::print(Print& outputDev)
   }
 }
 
+/**
+ * @brief      Set crash information that has been previusly saved in EEPROM to user buffer
+ * @param      userBuffer  The user buffer
+ */
+void EspSaveCrash::crashToBuffer(char* userBuffer)
+{
+  char *tmpBuffer = (char*)calloc(2048, sizeof(char));
+
+  // Note that 'EEPROM.begin' method is reserving a RAM buffer
+  // The buffer size is SAVE_CRASH_EEPROM_OFFSET + SAVE_CRASH_SPACE_SIZE
+  EEPROM.begin(_offset + _size);
+  byte crashCounter = EEPROM.read(_offset + SAVE_CRASH_COUNTER);
+  if (crashCounter == 0)
+  {
+    // outputDev.println("No crashes saved");
+    strcpy(userBuffer, "No crashes saved");
+    return;
+  }
+
+  // outputDev.println("Crash information recovered from EEPROM");
+  strcat(userBuffer, "Crash information recovered from EEPROM\n");
+
+  int16_t readFrom = _offset + SAVE_CRASH_DATA_SETS;
+  for (byte k = 0; k < crashCounter; k++)
+  {
+    uint32_t crashTime;
+    EEPROM.get(readFrom + SAVE_CRASH_CRASH_TIME, crashTime);
+    // outputDev.printf("Crash # %d at %ld ms\n", k + 1, crashTime);
+    sprintf(tmpBuffer, "Crash # %d at %ld ms\n", k + 1, crashTime);
+    strcat(userBuffer, tmpBuffer);
+
+    // outputDev.printf("Restart reason: %d\n", EEPROM.read(readFrom + SAVE_CRASH_RESTART_REASON));
+    sprintf(tmpBuffer, "Restart reason: %d\n", EEPROM.read(readFrom + SAVE_CRASH_RESTART_REASON));
+    strcat(userBuffer, tmpBuffer);
+
+    // outputDev.printf("Exception cause: %d\n", EEPROM.read(readFrom + SAVE_CRASH_EXCEPTION_CAUSE));
+    sprintf(tmpBuffer, "Exception cause: %d\n", EEPROM.read(readFrom + SAVE_CRASH_EXCEPTION_CAUSE));
+    strcat(userBuffer, tmpBuffer);
+
+    uint32_t epc1, epc2, epc3, excvaddr, depc;
+    EEPROM.get(readFrom + SAVE_CRASH_EPC1, epc1);
+    EEPROM.get(readFrom + SAVE_CRASH_EPC2, epc2);
+    EEPROM.get(readFrom + SAVE_CRASH_EPC3, epc3);
+    EEPROM.get(readFrom + SAVE_CRASH_EXCVADDR, excvaddr);
+    EEPROM.get(readFrom + SAVE_CRASH_DEPC, depc);
+    // outputDev.printf("epc1=0x%08x epc2=0x%08x epc3=0x%08x excvaddr=0x%08x depc=0x%08x\n", epc1, epc2, epc3, excvaddr, depc);
+    sprintf(tmpBuffer, "epc1=0x%08x epc2=0x%08x epc3=0x%08x excvaddr=0x%08x depc=0x%08x\n", epc1, epc2, epc3, excvaddr, depc);
+    strcat(userBuffer, tmpBuffer);
+
+    uint32_t stackStart, stackEnd;
+    EEPROM.get(readFrom + SAVE_CRASH_STACK_START, stackStart);
+    EEPROM.get(readFrom + SAVE_CRASH_STACK_END, stackEnd);
+    // outputDev.println(">>>stack>>>");
+    sprintf(tmpBuffer, ">>>stack>>>\n");
+    strcat(userBuffer, tmpBuffer);
+
+    int16_t currentAddress = readFrom + SAVE_CRASH_STACK_TRACE;
+    int16_t stackLength = stackEnd - stackStart;
+    uint32_t stackTrace;
+    for (int16_t i = 0; i < stackLength; i += 0x10)
+    {
+      // outputDev.printf("%08x: ", stackStart + i);
+      sprintf(tmpBuffer, "%08x: ", stackStart + i);
+      strcat(userBuffer, tmpBuffer);
+
+      for (byte j = 0; j < 4; j++)
+      {
+        EEPROM.get(currentAddress, stackTrace);
+        // outputDev.printf("%08x ", stackTrace);
+        sprintf(tmpBuffer, "%08x ", stackTrace);
+        strcat(userBuffer, tmpBuffer);
+
+        currentAddress += 4;
+        if (currentAddress - _offset > _size)
+        {
+          // outputDev.println("\nIncomplete stack trace saved!");
+          sprintf(tmpBuffer, "\nIncomplete stack trace saved!\n");
+          strcat(userBuffer, tmpBuffer);
+
+          goto eepromSpaceEnd;
+        }
+      }
+      // outputDev.println();
+      strcat(userBuffer, "\n");
+
+    }
+    eepromSpaceEnd:
+    // outputDev.println("<<<stack<<<");
+    strcat(userBuffer, "<<<stack<<<\n");
+
+    readFrom = readFrom + SAVE_CRASH_STACK_TRACE + stackLength;
+  }
+  int16_t writeFrom;
+  EEPROM.get(_offset + SAVE_CRASH_WRITE_FROM, writeFrom);
+  EEPROM.end();
+
+  // is there free EEPROM space avialable to save data for next crash?
+  if (writeFrom + SAVE_CRASH_STACK_TRACE > _size)
+  {
+    // outputDev.println("No more EEPROM space available to save crash information!");
+    strcat(userBuffer, "No more EEPROM space available to save crash information!\n");
+  }
+  else
+  {
+    // outputDev.printf("EEPROM space available: 0x%04x bytes\n", _size - writeFrom);
+    sprintf(tmpBuffer, "EEPROM space available: 0x%04x bytes\n", _size - writeFrom);
+    strcat(userBuffer, tmpBuffer);
+  }
+
+  free(tmpBuffer);
+}
 
 /**
  * Get the count of crash data sets saved in EEPROM

--- a/src/EspSaveCrash.h
+++ b/src/EspSaveCrash.h
@@ -78,11 +78,13 @@
 #define SAVE_CRASH_STACK_TRACE      0x22  // variable
 
 
-class EspSaveCrash 
+class EspSaveCrash
 {
   public:
     EspSaveCrash(uint16_t = 0x0010, uint16_t = 0x0200);
     void print(Print& outDevice = Serial);
+    void crashToBuffer(char* userBuffer);
+
     void clear();
     int count();
     uint16_t offset();


### PR DESCRIPTION
instead of only printing to console or webserver the crash log data can be handed over to a custom user buffer with the crashToBuffer(char* someBuffer) function. This allows also setting up an ESP webserver showing the log as a seperate page