### PR TITLE
added _persistEEPROM

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -177,11 +177,16 @@ Crash data is saved using the [EEPROM](https://github.com/esp8266/Arduino/blob/m
 
 If you like to change flash memory space reserved for storing crash information use class constructor. The maximum value is `4096` (`0x1000`) bytes as defined for the [EEPROM](https://github.com/esp8266/Arduino/blob/master/doc/libraries.md#eeprom) library.
 
-You may have other applications already using EEPROM. Passing an offset parameter to the constructor leaves initial EEPROM space for the other applications. Optionally you can use upper EEPROM space (i.e. above `_offset` + `_size`).
+You may have other applications already using EEPROM in which case you must set a third parameter (shown below) in the constructor to set EEPROM to persistent, otherwise the libary will assume EEPROM is not being used by your application and performs EEPROM.end(). Passing an offset parameter to the constructor leaves initial EEPROM space for the other applications. Optionally you can use upper EEPROM space (i.e. above `_offset` + `_size`).
 
 ```cpp
 //Offset, Size
 EspSaveCrash SaveCrash(0x0010, 0x0200);
+```
+
+```cpp
+//Offset, Size, Persistent EEPROM
+EspSaveCrash SaveCrash(0x0010, 0x0200, true);
 ```
 
 Picture below shows relationship between both configuration parameters and total available EEPROM space.

--- a/src/EspSaveCrash.cpp
+++ b/src/EspSaveCrash.cpp
@@ -115,7 +115,7 @@ extern "C" void custom_crash_callback(struct rst_info * rst_info, uint32_t stack
 /**
  * The class constructor
  */
-EspSaveCrash::EspSaveCrash(uint16_t off, uint16_t size, bool persistEEPROM = false)
+EspSaveCrash::EspSaveCrash(uint16_t off, uint16_t size, bool persistEEPROM)
 {
   _offset = off;
   _size = size;

--- a/src/EspSaveCrash.cpp
+++ b/src/EspSaveCrash.cpp
@@ -37,6 +37,7 @@
  */
 uint16_t EspSaveCrash::_offset = 0x0010;
 uint16_t EspSaveCrash::_size = 0x0200;
+bool EspSaveCrash::_persistEEPROM = false;
 
 /**
  * Save crash information in EEPROM
@@ -114,10 +115,11 @@ extern "C" void custom_crash_callback(struct rst_info * rst_info, uint32_t stack
 /**
  * The class constructor
  */
-EspSaveCrash::EspSaveCrash(uint16_t off, uint16_t size)
+EspSaveCrash::EspSaveCrash(uint16_t off, uint16_t size, bool persistEEPROM = false)
 {
   _offset = off;
   _size = size;
+  _persistEEPROM = persistEEPROM;
 }
 
 /**
@@ -132,7 +134,8 @@ void EspSaveCrash::clear(void)
   EEPROM.begin(_offset + _size);
   // clear the crash counter
   EEPROM.write(_offset + SAVE_CRASH_COUNTER, 0);
-  EEPROM.end();
+  if(!_persistEEPROM) EEPROM.end();
+  else EEPROM.commit();
 }
 
 
@@ -200,7 +203,8 @@ void EspSaveCrash::print(Print& outputDev)
   }
   int16_t writeFrom;
   EEPROM.get(_offset + SAVE_CRASH_WRITE_FROM, writeFrom);
-  EEPROM.end();
+  if(!_persistEEPROM) EEPROM.end();
+  else EEPROM.commit();
 
   // is there free EEPROM space available to save data for next crash?
   if (writeFrom + SAVE_CRASH_STACK_TRACE > _size)
@@ -262,7 +266,8 @@ int EspSaveCrash::count()
 {
   EEPROM.begin(_offset + _size);
   int crashCounter = EEPROM.read(_offset + SAVE_CRASH_COUNTER);
-  EEPROM.end();
+  if(!_persistEEPROM) EEPROM.end();
+  else EEPROM.commit();
   return crashCounter;
 }
 

--- a/src/EspSaveCrash.cpp
+++ b/src/EspSaveCrash.cpp
@@ -134,8 +134,12 @@ void EspSaveCrash::clear(void)
   EEPROM.begin(_offset + _size);
   // clear the crash counter
   EEPROM.write(_offset + SAVE_CRASH_COUNTER, 0);
-  if(!_persistEEPROM) EEPROM.end();
-  else EEPROM.commit();
+  if(!_persistEEPROM){
+    EEPROM.end();
+  }
+  else{
+    EEPROM.commit();
+  }
 }
 
 
@@ -203,8 +207,12 @@ void EspSaveCrash::print(Print& outputDev)
   }
   int16_t writeFrom;
   EEPROM.get(_offset + SAVE_CRASH_WRITE_FROM, writeFrom);
-  if(!_persistEEPROM) EEPROM.end();
-  else EEPROM.commit();
+  if(!_persistEEPROM){
+    EEPROM.end();
+  }
+  else{
+    EEPROM.commit();
+  }
 
   // is there free EEPROM space available to save data for next crash?
   if (writeFrom + SAVE_CRASH_STACK_TRACE > _size)
@@ -266,8 +274,12 @@ int EspSaveCrash::count()
 {
   EEPROM.begin(_offset + _size);
   int crashCounter = EEPROM.read(_offset + SAVE_CRASH_COUNTER);
-  if(!_persistEEPROM) EEPROM.end();
-  else EEPROM.commit();
+  if(!_persistEEPROM){
+    EEPROM.end();
+  }
+  else{
+    EEPROM.commit();
+  }
   return crashCounter;
 }
 

--- a/src/EspSaveCrash.h
+++ b/src/EspSaveCrash.h
@@ -96,6 +96,7 @@ class EspSaveCrash
     //These have to be public in order to be accessed by callback
     static uint16_t _offset;
     static uint16_t _size;
+    static bool _persistEEPROM;
   private:
     // none
 };

--- a/src/EspSaveCrash.h
+++ b/src/EspSaveCrash.h
@@ -81,7 +81,7 @@
 class EspSaveCrash
 {
   public:
-    EspSaveCrash(uint16_t = 0x0010, uint16_t = 0x0200);
+    EspSaveCrash(uint16_t = 0x0010, uint16_t = 0x0200, bool = false);
     void print(Print& outDevice = Serial);
     size_t print(char* userBuffer, size_t size);
 


### PR DESCRIPTION
This allows users who are already using EEPROM to continue in an intuitive way and not have this library close the EEPROM by calling EEPROM.end() within the library. Now in the constructor if you set persistent = true then this library will commit() instead of .end().