### PR TITLE
User EEPROM Size

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -177,11 +177,16 @@ Crash data is saved using the [EEPROM](https://github.com/esp8266/Arduino/blob/m
 
 If you like to change flash memory space reserved for storing crash information use class constructor. The maximum value is `4096` (`0x1000`) bytes as defined for the [EEPROM](https://github.com/esp8266/Arduino/blob/master/doc/libraries.md#eeprom) library.
 
-You may have other applications already using EEPROM. Passing an offset parameter to the constructor leaves initial EEPROM space for the other applications. Optionally you can use upper EEPROM space (i.e. above `_offset` + `_size`).
+You may have other applications already using EEPROM in which case you must set a third parameter (shown below) in the constructor to set EEPROM to persistent, otherwise the libary will assume EEPROM is not being used by your application and performs EEPROM.end(). Passing an offset parameter to the constructor leaves initial EEPROM space for the other applications. Optionally you can use upper EEPROM space (i.e. above `_offset` + `_size`).
 
 ```cpp
 //Offset, Size
 EspSaveCrash SaveCrash(0x0010, 0x0200);
+```
+
+```cpp
+//Offset, Size, Persistent EEPROM
+EspSaveCrash SaveCrash(0x0010, 0x0200, true);
 ```
 
 Picture below shows relationship between both configuration parameters and total available EEPROM space.

--- a/examples.md
+++ b/examples.md
@@ -186,7 +186,7 @@ EspSaveCrash SaveCrash(0x0010, 0x0200);
 
 ```cpp
 //Offset, Size, Persistent EEPROM
-EspSaveCrash SaveCrash(0x0010, 0x0200, true);
+EspSaveCrash SaveCrash(0x0010, 0x0200, YOUR_APP_EEPROM_SIZE);
 ```
 
 Picture below shows relationship between both configuration parameters and total available EEPROM space.

--- a/src/EspSaveCrash.cpp
+++ b/src/EspSaveCrash.cpp
@@ -48,7 +48,9 @@ extern "C" void custom_crash_callback(struct rst_info * rst_info, uint32_t stack
 {
   // Note that 'EEPROM.begin' method is reserving a RAM buffer
   // The buffer size is SAVE_CRASH_EEPROM_OFFSET + SAVE_CRASH_SPACE_SIZE
-  EEPROM.begin(EspSaveCrash::_offset + EspSaveCrash::_size);
+  if(EEPROM.length() == 0){
+    EEPROM.begin(EspSaveCrash::_EEPROM_size);
+  }
 
   byte crashCounter = EEPROM.read(EspSaveCrash::_offset + SAVE_CRASH_COUNTER);
   int16_t writeFrom;
@@ -119,7 +121,7 @@ EspSaveCrash::EspSaveCrash(uint16_t off, uint16_t size, uint16_t EEPROM_size)
 {
   _offset = off;
   _size = size;
-  _EEPROM_size = EEPROM_size == 0 ? _offset + _size : EEPROM_size;
+  _EEPROM_size = EEPROM_size == 0 ? (_offset + _size) : EEPROM_size;
 }
 
 /**
@@ -131,7 +133,9 @@ void EspSaveCrash::clear(void)
 {
   // Note that 'EEPROM.begin' method is reserving a RAM buffer
   // The buffer size is SAVE_CRASH_EEPROM_OFFSET + SAVE_CRASH_SPACE_SIZE
-  EEPROM.begin(_EEPROM_size);
+  if(EEPROM.length() == 0){
+    EEPROM.begin(_EEPROM_size);
+  }
   // clear the crash counter
   EEPROM.write(_offset + SAVE_CRASH_COUNTER, 0);
   if(!_EEPROM_size){
@@ -151,7 +155,9 @@ void EspSaveCrash::print(Print& outputDev)
 {
   // Note that 'EEPROM.begin' method is reserving a RAM buffer
   // The buffer size is SAVE_CRASH_EEPROM_OFFSET + SAVE_CRASH_SPACE_SIZE
-  EEPROM.begin(_EEPROM_size);
+  if(EEPROM.length() == 0){
+    EEPROM.begin(_EEPROM_size);
+  }
   byte crashCounter = EEPROM.read(_offset + SAVE_CRASH_COUNTER);
   if (crashCounter == 0)
   {
@@ -272,7 +278,9 @@ void EspSaveCrash::crashToBuffer(char* userBuffer)
  */
 int EspSaveCrash::count()
 {
-  EEPROM.begin(_EEPROM_size);
+  if(EEPROM.length() == 0){
+    EEPROM.begin(_EEPROM_size);
+  }
   int crashCounter = EEPROM.read(_offset + SAVE_CRASH_COUNTER);
   if(!_EEPROM_size){
     EEPROM.end();

--- a/src/EspSaveCrash.cpp
+++ b/src/EspSaveCrash.cpp
@@ -115,7 +115,7 @@ extern "C" void custom_crash_callback(struct rst_info * rst_info, uint32_t stack
 /**
  * The class constructor
  */
-EspSaveCrash::EspSaveCrash(uint16_t off, uint16_t size, bool persistEEPROM = false)
+EspSaveCrash::EspSaveCrash(uint16_t off, uint16_t size, bool persistEEPROM)
 {
   _offset = off;
   _size = size;

--- a/src/EspSaveCrash.cpp
+++ b/src/EspSaveCrash.cpp
@@ -37,7 +37,7 @@
  */
 uint16_t EspSaveCrash::_offset = 0x0010;
 uint16_t EspSaveCrash::_size = 0x0200;
-bool EspSaveCrash::_persistEEPROM = false;
+uint16_t EspSaveCrash::_EEPROM_size = 0;
 
 /**
  * Save crash information in EEPROM
@@ -115,11 +115,11 @@ extern "C" void custom_crash_callback(struct rst_info * rst_info, uint32_t stack
 /**
  * The class constructor
  */
-EspSaveCrash::EspSaveCrash(uint16_t off, uint16_t size, bool persistEEPROM)
+EspSaveCrash::EspSaveCrash(uint16_t off, uint16_t size, uint16_t EEPROM_size)
 {
   _offset = off;
   _size = size;
-  _persistEEPROM = persistEEPROM;
+  _EEPROM_size = EEPROM_size == 0 ? _offset + _size : EEPROM_size;
 }
 
 /**
@@ -131,10 +131,10 @@ void EspSaveCrash::clear(void)
 {
   // Note that 'EEPROM.begin' method is reserving a RAM buffer
   // The buffer size is SAVE_CRASH_EEPROM_OFFSET + SAVE_CRASH_SPACE_SIZE
-  EEPROM.begin(_offset + _size);
+  EEPROM.begin(_EEPROM_size);
   // clear the crash counter
   EEPROM.write(_offset + SAVE_CRASH_COUNTER, 0);
-  if(!_persistEEPROM){
+  if(!_EEPROM_size){
     EEPROM.end();
   }
   else{
@@ -151,7 +151,7 @@ void EspSaveCrash::print(Print& outputDev)
 {
   // Note that 'EEPROM.begin' method is reserving a RAM buffer
   // The buffer size is SAVE_CRASH_EEPROM_OFFSET + SAVE_CRASH_SPACE_SIZE
-  EEPROM.begin(_offset + _size);
+  EEPROM.begin(_EEPROM_size);
   byte crashCounter = EEPROM.read(_offset + SAVE_CRASH_COUNTER);
   if (crashCounter == 0)
   {
@@ -207,7 +207,7 @@ void EspSaveCrash::print(Print& outputDev)
   }
   int16_t writeFrom;
   EEPROM.get(_offset + SAVE_CRASH_WRITE_FROM, writeFrom);
-  if(!_persistEEPROM){
+  if(!_EEPROM_size){
     EEPROM.end();
   }
   else{
@@ -272,9 +272,9 @@ void EspSaveCrash::crashToBuffer(char* userBuffer)
  */
 int EspSaveCrash::count()
 {
-  EEPROM.begin(_offset + _size);
+  EEPROM.begin(_EEPROM_size);
   int crashCounter = EEPROM.read(_offset + SAVE_CRASH_COUNTER);
-  if(!_persistEEPROM){
+  if(!_EEPROM_size){
     EEPROM.end();
   }
   else{

--- a/src/EspSaveCrash.cpp
+++ b/src/EspSaveCrash.cpp
@@ -37,6 +37,7 @@
  */
 uint16_t EspSaveCrash::_offset = 0x0010;
 uint16_t EspSaveCrash::_size = 0x0200;
+bool EspSaveCrash::_persistEEPROM = false;
 
 /**
  * Save crash information in EEPROM
@@ -114,10 +115,11 @@ extern "C" void custom_crash_callback(struct rst_info * rst_info, uint32_t stack
 /**
  * The class constructor
  */
-EspSaveCrash::EspSaveCrash(uint16_t off, uint16_t size)
+EspSaveCrash::EspSaveCrash(uint16_t off, uint16_t size, bool persistEEPROM = false)
 {
   _offset = off;
   _size = size;
+  _persistEEPROM = persistEEPROM;
 }
 
 /**
@@ -132,7 +134,8 @@ void EspSaveCrash::clear(void)
   EEPROM.begin(_offset + _size);
   // clear the crash counter
   EEPROM.write(_offset + SAVE_CRASH_COUNTER, 0);
-  EEPROM.end();
+  if(!_persistEEPROM) EEPROM.end();
+  else EEPROM.commit();
 }
 
 
@@ -200,7 +203,8 @@ void EspSaveCrash::print(Print& outputDev)
   }
   int16_t writeFrom;
   EEPROM.get(_offset + SAVE_CRASH_WRITE_FROM, writeFrom);
-  EEPROM.end();
+  if(!_persistEEPROM) EEPROM.end();
+  else EEPROM.commit();
 
   // is there free EEPROM space available to save data for next crash?
   if (writeFrom + SAVE_CRASH_STACK_TRACE > _size)
@@ -262,7 +266,8 @@ int EspSaveCrash::count()
 {
   EEPROM.begin(_offset + _size);
   int crashCounter = EEPROM.read(_offset + SAVE_CRASH_COUNTER);
-  EEPROM.end();
+  if(!_persistEEPROM) EEPROM.end();
+  else EEPROM.commit();
   return crashCounter;
 }
 

--- a/src/EspSaveCrash.cpp
+++ b/src/EspSaveCrash.cpp
@@ -134,8 +134,12 @@ void EspSaveCrash::clear(void)
   EEPROM.begin(_offset + _size);
   // clear the crash counter
   EEPROM.write(_offset + SAVE_CRASH_COUNTER, 0);
-  if(!_persistEEPROM) EEPROM.end();
-  else EEPROM.commit();
+  if(!_persistEEPROM){
+    EEPROM.end();
+  }
+  else{
+    EEPROM.commit();
+  }
 }
 
 
@@ -203,8 +207,12 @@ void EspSaveCrash::print(Print& outputDev)
   }
   int16_t writeFrom;
   EEPROM.get(_offset + SAVE_CRASH_WRITE_FROM, writeFrom);
-  if(!_persistEEPROM) EEPROM.end();
-  else EEPROM.commit();
+  if(!_persistEEPROM){
+    EEPROM.end();
+  }
+  else{
+    EEPROM.commit();
+  }
 
   // is there free EEPROM space available to save data for next crash?
   if (writeFrom + SAVE_CRASH_STACK_TRACE > _size)
@@ -266,8 +274,12 @@ int EspSaveCrash::count()
 {
   EEPROM.begin(_offset + _size);
   int crashCounter = EEPROM.read(_offset + SAVE_CRASH_COUNTER);
-  if(!_persistEEPROM) EEPROM.end();
-  else EEPROM.commit();
+  if(!_persistEEPROM){
+    EEPROM.end();
+  }
+  else{
+    EEPROM.commit();
+  }
   return crashCounter;
 }
 

--- a/src/EspSaveCrash.h
+++ b/src/EspSaveCrash.h
@@ -81,7 +81,7 @@
 class EspSaveCrash
 {
   public:
-    EspSaveCrash(uint16_t = 0x0010, uint16_t = 0x0200, bool = false);
+    EspSaveCrash(uint16_t = 0x0010, uint16_t = 0x0200, uint16_t = 0);
     void print(Print& outDevice = Serial);
     size_t print(char* userBuffer, size_t size);
 
@@ -96,7 +96,7 @@ class EspSaveCrash
     //These have to be public in order to be accessed by callback
     static uint16_t _offset;
     static uint16_t _size;
-    static bool _persistEEPROM;
+    static uint16_t _EEPROM_size;
   private:
     // none
 };

--- a/src/EspSaveCrash.h
+++ b/src/EspSaveCrash.h
@@ -96,6 +96,7 @@ class EspSaveCrash
     //These have to be public in order to be accessed by callback
     static uint16_t _offset;
     static uint16_t _size;
+    static bool _persistEEPROM;
   private:
     // none
 };

--- a/src/EspSaveCrash.h
+++ b/src/EspSaveCrash.h
@@ -81,7 +81,7 @@
 class EspSaveCrash
 {
   public:
-    EspSaveCrash(uint16_t = 0x0010, uint16_t = 0x0200);
+    EspSaveCrash(uint16_t = 0x0010, uint16_t = 0x0200, bool = false);
     void print(Print& outDevice = Serial);
     size_t print(char* userBuffer, size_t size);
 


### PR DESCRIPTION
Sorry to submit this just days after the previous PR. I just came across the fact that if the user sketch is using EEPROM at one size that doesn't match _offset + _size then the .begin() call within EspCrashSave will delete and reallocate the buffer which will clear out all of the user's uncommited data and then reallocate the EEPROM buffer to a different (possibly smaller size). I changed the way that we indicate _peristentEEPROM from the previous PR from a bool to the actual size of the user's EEPROM. That way, if the user specifies a EEPROM size then that size will be used by all .begin() calls within EspCrashSave.