### PR TITLE
Add callback and use IRAM heap if configured

### DIFF
--- a/src/EspSaveCrash.cpp
+++ b/src/EspSaveCrash.cpp
@@ -38,6 +38,7 @@
 uint16_t EspSaveCrash::_offset = 0x0010;
 uint16_t EspSaveCrash::_size = 0x0200;
 bool EspSaveCrash::_persistEEPROM = false;
+void (*EspSaveCrash::_callback)() = NULL;
 
 /**
  * Save crash information in EEPROM
@@ -123,17 +124,22 @@ extern "C" void custom_crash_callback(struct rst_info * rst_info, uint32_t stack
   EEPROM.put(EspSaveCrash::_offset + SAVE_CRASH_WRITE_FROM, currentAddress);
 
   EEPROM.commit();
+
+  // If callback function provided, call it now
+  if (EspSaveCrash::_callback)
+    EspSaveCrash::_callback();
 }
 
 
 /**
  * The class constructor
  */
-EspSaveCrash::EspSaveCrash(uint16_t off, uint16_t size, bool persistEEPROM)
+EspSaveCrash::EspSaveCrash(uint16_t off, uint16_t size, bool persistEEPROM, void (*callback)())
 {
   _offset = off;
   _size = size;
   _persistEEPROM = persistEEPROM;
+  _callback = callback;
 }
 
 /**

--- a/src/EspSaveCrash.cpp
+++ b/src/EspSaveCrash.cpp
@@ -27,6 +27,10 @@
 */
 
 #include "EspSaveCrash.h"
+#if defined(MMU_IRAM_HEAP)
+#include <umm_malloc/umm_malloc.h>
+#include <umm_malloc/umm_heap_select.h>
+#endif
 
 /**
  * EEPROM layout
@@ -49,7 +53,12 @@ extern "C" void custom_crash_callback(struct rst_info * rst_info, uint32_t stack
 {
   // Note that 'EEPROM.begin' method is reserving a RAM buffer
   // The buffer size is SAVE_CRASH_EEPROM_OFFSET + SAVE_CRASH_SPACE_SIZE
-  EEPROM.begin(EspSaveCrash::_offset + EspSaveCrash::_size);
+  {
+#if defined(MMU_IRAM_HEAP)
+    HeapSelectIram ephemeral;
+#endif
+    EEPROM.begin(EspSaveCrash::_offset + EspSaveCrash::_size);
+  }
 
   byte crashCounter = EEPROM.read(EspSaveCrash::_offset + SAVE_CRASH_COUNTER);
   int16_t writeFrom;
@@ -151,7 +160,12 @@ void EspSaveCrash::clear(void)
 {
   // Note that 'EEPROM.begin' method is reserving a RAM buffer
   // The buffer size is SAVE_CRASH_EEPROM_OFFSET + SAVE_CRASH_SPACE_SIZE
-  EEPROM.begin(_offset + _size);
+  {
+#if defined(MMU_IRAM_HEAP)
+    HeapSelectIram ephemeral;
+#endif
+    EEPROM.begin(_offset + _size);
+  }
   // clear the crash counter
   EEPROM.write(_offset + SAVE_CRASH_COUNTER, 0);
   if(!_persistEEPROM){
@@ -171,7 +185,12 @@ void EspSaveCrash::print(Print& outputDev)
 {
   // Note that 'EEPROM.begin' method is reserving a RAM buffer
   // The buffer size is SAVE_CRASH_EEPROM_OFFSET + SAVE_CRASH_SPACE_SIZE
-  EEPROM.begin(_offset + _size);
+  {
+#if defined(MMU_IRAM_HEAP)
+    HeapSelectIram ephemeral;
+#endif
+    EEPROM.begin(_offset + _size);
+  }
   byte crashCounter = EEPROM.read(_offset + SAVE_CRASH_COUNTER);
   if (crashCounter == 0)
   {
@@ -298,7 +317,12 @@ void EspSaveCrash::crashToBuffer(char* userBuffer)
  */
 int EspSaveCrash::count()
 {
-  EEPROM.begin(_offset + _size);
+  {
+#if defined(MMU_IRAM_HEAP)
+    HeapSelectIram ephemeral;
+#endif
+    EEPROM.begin(_offset + _size);
+  }
   int crashCounter = EEPROM.read(_offset + SAVE_CRASH_COUNTER);
   if(!_persistEEPROM){
     EEPROM.end();

--- a/src/EspSaveCrash.h
+++ b/src/EspSaveCrash.h
@@ -81,7 +81,7 @@
 class EspSaveCrash
 {
   public:
-    EspSaveCrash(uint16_t = 0x0010, uint16_t = 0x0200, bool = false);
+    EspSaveCrash(uint16_t = 0x0010, uint16_t = 0x0200, bool = false, void (*)() = NULL);
     void print(Print& outDevice = Serial);
     size_t print(char* userBuffer, size_t size);
 
@@ -97,6 +97,7 @@ class EspSaveCrash
     static uint16_t _offset;
     static uint16_t _size;
     static bool _persistEEPROM;
+    static void (*_callback)();
   private:
     // none
 };


### PR DESCRIPTION
Offering enhancements we added when developing HomeKit-RATGDO project...

1. Add an optional callback to user code after crash is saved.
2. Use IRAM heap if compiled with shared 2nd heap option.  See [documentation](https://arduino-esp8266.readthedocs.io/en/latest/mmu.html) and [here](https://docs.platformio.org/en/stable/platforms/espressif8266.html#mmu-adjusting-icache-to-iram-ratio).  This saves valuable space for the application in the main heap.
3. Fix output of certain exception types so can be properly decoded